### PR TITLE
Corrected 06_patient_spec.rb

### DIFF
--- a/spec/06_patient_spec.rb
+++ b/spec/06_patient_spec.rb
@@ -39,6 +39,7 @@ describe 'Patient' do
       expect(steve.appointments).to include(appointment_one)
       expect(steve.appointments).to include(appointment_two)
     end
+  end
 
   describe '#doctors' do
     it 'has many doctors through appointments' do


### PR DESCRIPTION
Added a missing an "end" to close "describe #appointments" section. It was giving a syntax error when trying to run IDE tests.